### PR TITLE
more informative log messages

### DIFF
--- a/hodl-miner.c
+++ b/hodl-miner.c
@@ -1339,7 +1339,8 @@ start:
 		}
 		if (likely(val)) {
 			bool rc;
-			applog(LOG_INFO, "LONGPOLL pushed new work");
+			applog(LOG_INFO, "LONGPOLL pushed new work for block %d, target %04X",
+                                                    g_work.height, g_work.target[7]);
 			res = json_object_get(val, "result");
 			soval = json_object_get(res, "submitold");
 			submit_old = soval ? json_is_true(soval) : false;


### PR DESCRIPTION
Do you like such logging:

```
[2018-01-06 22:13:54] 32 miner threads started, using 'hodl' algorithm.
[2018-01-06 22:13:54] Long-polling activated for http://10.0.100.10:3379
[2018-01-06 22:14:57] LONGPOLL pushed new work for block 36173, target 02C8
[2018-01-06 22:20:47] LONGPOLL pushed new work for block 36174, target 02C8
[2018-01-06 22:21:34] LONGPOLL pushed new work for block 36175, target 02C8
```