### PR TITLE
use openssl's RAND_bytes to get better entropy

### DIFF
--- a/hodl-miner.c
+++ b/hodl-miner.c
@@ -104,6 +104,7 @@ int pthread_barrier_wait(pthread_barrier_t *barrier)
 #endif
 #include <jansson.h>
 #include <curl/curl.h>
+#include <openssl/rand.h>
 #include "compat.h"
 #include "miner.h"
 #include "hodl.h"
@@ -1208,10 +1209,14 @@ static void *miner_thread(void *userdata)
 		    }
 		    pthread_mutex_unlock(&g_work_lock);
 
-		    nNonce = (clock()+rand())%9999;
+		    if (likely(1 == RAND_bytes((unsigned char*)&nNonce, sizeof(nNonce)))) {
+			nNonce = nNonce % 9999;
+		    } else {
+		    	nNonce = (clock()+rand())%9999;
+		    }
 		}
-		
-		pthread_barrier_wait( &bar );		
+
+		pthread_barrier_wait( &bar );
 
 		if (memcmp(work.data, hodl_work.data, 76)) {
             work_free(&work);


### PR DESCRIPTION
I'd like to suggest you to use RAND_bytes because it is platform independent source of acceptable entropy. On linux it uses /dev/urandom which is fast nonblocking source of pseudorandom values. Using this will decrease probability of hammering with same nNonce on the block and increase the probability to catch the solution.