### PR TITLE
Made holdminer to compile on native OSX

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+Build.My
+Pull.Master
 
 hodlminer
 hodlminer.exe
@@ -16,7 +18,7 @@ depcomp
 missing
 install-sh
 stamp-h1
-cpuminer-config.h*
+hodlminer-config.h*
 compile
 config.log
 config.status

--- a/Makefile.am
+++ b/Makefile.am
@@ -1,4 +1,4 @@
-CC = gcc
+# CC = gcc
 AM_CFLAGS = -Wall
 
 if WANT_JANSSON

--- a/sha512_avx2.c
+++ b/sha512_avx2.c
@@ -9,7 +9,7 @@
 
 #include "sha512.h"
 
-#if ((defined(_WIN64) || defined(__WINDOWS__)))
+#if defined(_WIN64) || defined(__WINDOWS__) || defined(__APPLE__)
 #include "hodl-endian.h"
 #endif
 
@@ -78,57 +78,48 @@ static const uint64_t k[80] =
    0x4CC5D4BECB3E42B6, 0x597F299CFC657E2A, 0x5FCB6FAB3AD6FAEC, 0x6C44198C4A475817
 };
 
+//SHA-512 seed
+static const uint64_t init[8] =
+{
+    0x6A09E667F3BCC908, 0xBB67AE8584CAA73B, 0x3C6EF372FE94F82B, 0xA54FF53A5F1D36F1,
+    0x510E527FADE682D1, 0x9B05688C2B3E6C1F, 0x1F83D9ABFB41BD6B, 0x5BE0CD19137E2179
+};
 
 void sha512Compute32b_parallel(uint64_t *data[SHA512_PARALLEL_N], uint64_t *digest[SHA512_PARALLEL_N]) {
     Sha512Context context[2];
-    context[0].h[0] = _mm256_set1_epi64x(0x6A09E667F3BCC908);
-    context[0].h[1] = _mm256_set1_epi64x(0xBB67AE8584CAA73B);
-    context[0].h[2] = _mm256_set1_epi64x(0x3C6EF372FE94F82B);
-    context[0].h[3] = _mm256_set1_epi64x(0xA54FF53A5F1D36F1);
-    context[0].h[4] = _mm256_set1_epi64x(0x510E527FADE682D1);
-    context[0].h[5] = _mm256_set1_epi64x(0x9B05688C2B3E6C1F);
-    context[0].h[6] = _mm256_set1_epi64x(0x1F83D9ABFB41BD6B);
-    context[0].h[7] = _mm256_set1_epi64x(0x5BE0CD19137E2179);
+    int i;
+    
+    for (i=0; i<8; i++) {
+	context[0].h[i] = context[1].h[i] = _mm256_set1_epi64x(init[i]);
+    }
 
-    context[1].h[0] = _mm256_set1_epi64x(0x6A09E667F3BCC908);
-    context[1].h[1] = _mm256_set1_epi64x(0xBB67AE8584CAA73B);
-    context[1].h[2] = _mm256_set1_epi64x(0x3C6EF372FE94F82B);
-    context[1].h[3] = _mm256_set1_epi64x(0xA54FF53A5F1D36F1);
-    context[1].h[4] = _mm256_set1_epi64x(0x510E527FADE682D1);
-    context[1].h[5] = _mm256_set1_epi64x(0x9B05688C2B3E6C1F);
-    context[1].h[6] = _mm256_set1_epi64x(0x1F83D9ABFB41BD6B);
-    context[1].h[7] = _mm256_set1_epi64x(0x5BE0CD19137E2179);
-
-    for(int i=0; i<4; ++i) {
+    for (i=0; i<4; ++i) {
         context[0].w[i] = _mm256_set_epi64x ( data[3][i], data[2][i], data[1][i], data[0][i] );
         context[1].w[i] = _mm256_set_epi64x ( data[7][i], data[6][i], data[5][i], data[4][i]  );
     }
-    for(int i=0; i<10; ++i) {
-        context[0].w[i+4] = _mm256_set1_epi64x( ((uint64_t*)padding)[i] );
-        context[1].w[i+4] = _mm256_set1_epi64x( ((uint64_t*)padding)[i] );
+
+    for (i=0; i<10; ++i) {
+        context[0].w[i+4] = context[1].w[i+4] = _mm256_set1_epi64x(padding[i]);
     }
 
     //Length of the original message (before padding)
     uint64_t totalSize = 32 * 8;
 
     //Append the length of the original message
-    context[0].w[14] = _mm256_set1_epi64x(0);
-    context[0].w[15] = _mm256_set1_epi64x(htobe64(totalSize));
-
-    context[1].w[14] = _mm256_set1_epi64x(0);
-    context[1].w[15] = _mm256_set1_epi64x(htobe64(totalSize));
+    context[0].w[14] = context[1].w[14] = _mm256_set1_epi64x(0);
+    context[0].w[15] = context[1].w[15] = _mm256_set1_epi64x(htobe64(totalSize));
 
     //Calculate the message digest
     sha512ProcessBlock(context);
 
     //Convert from host byte order to big-endian byte order
-    for (int i = 0; i < 8; i++) {
+    for (i = 0; i < 8; i++) {
         context[0].h[i] = mm256_htobe_epi64(context[0].h[i]);
         context[1].h[i] = mm256_htobe_epi64(context[1].h[i]);
     }
 
     //Copy the resulting digest
-    for(int i=0; i<8; ++i) {
+    for (i=0; i<8; ++i) {
         digest[0][i] = _mm256_extract_epi64(context[0].h[i], 0);
         digest[1][i] = _mm256_extract_epi64(context[0].h[i], 1);
         digest[2][i] = _mm256_extract_epi64(context[0].h[i], 2);
@@ -146,8 +137,8 @@ void sha512Compute32b_parallel(uint64_t *data[SHA512_PARALLEL_N], uint64_t *dige
                             SIGMA4(block[n][i - 2]) + block[n][i - 7])
 
 #define ROUND512(a,b,c,d,e,f,g,h)   \
-    T0 += (h[0]) + SIGMA2(e[0]) + Ch((e[0]), (f[0]), (g[0])) + k[i]; \
-    T1 += (h[1]) + SIGMA2(e[1]) + Ch((e[1]), (f[1]), (g[1])) + k[i]; \
+    T0 += (h[0]) + SIGMA2(e[0]) + Ch((e[0]), (f[0]), (g[0])) + _mm256_set1_epi64x(k[i]); \
+    T1 += (h[1]) + SIGMA2(e[1]) + Ch((e[1]), (f[1]), (g[1])) + _mm256_set1_epi64x(k[i]); \
     (d[0]) += T0; \
     (d[1]) += T1; \
     (h[0]) = T0 + SIGMA1(a[0]) + Maj((a[0]), (b[0]), (c[0])); \

--- a/sha512_sse2.c
+++ b/sha512_sse2.c
@@ -9,6 +9,10 @@
 
 #include "sha512.h"
 
+#if defined(_WIN64) || defined(__WINDOWS__) || defined(__APPLE__)
+#include "hodl-endian.h"
+#endif
+
 //SHA-512 auxiliary functions
 #define Ch(x, y, z) (((x) & (y)) | (~(x) & (z)))
 #define Maj(x, y, z) (((x) & (y)) | ((x) & (z)) | ((y) & (z)))
@@ -18,7 +22,7 @@
 #define SIGMA4(x) (ROR64(x, 19) ^ ROR64(x, 61) ^ SHR64(x, 6))
 
 //Rotate right operation
-#define ROR64(a, n) _mm_or_si128(_mm_srli_epi64(a, n), _mm_slli_epi64(a, sizeof(ulong)*8 - n))
+#define ROR64(a, n) _mm_or_si128(_mm_srli_epi64(a, n), _mm_slli_epi64(a, 64 - n))
 
 //Shift right operation
 #define SHR64(a, n) _mm_srli_epi64(a, n)
@@ -70,57 +74,48 @@ static const uint64_t k[80] =
    0x4CC5D4BECB3E42B6, 0x597F299CFC657E2A, 0x5FCB6FAB3AD6FAEC, 0x6C44198C4A475817
 };
 
+//SHA-512 seed
+static const uint64_t init[8] =
+{
+    0x6A09E667F3BCC908, 0xBB67AE8584CAA73B, 0x3C6EF372FE94F82B, 0xA54FF53A5F1D36F1,
+    0x510E527FADE682D1, 0x9B05688C2B3E6C1F, 0x1F83D9ABFB41BD6B, 0x5BE0CD19137E2179
+};
 
 void sha512Compute32b_parallel(uint64_t *data[SHA512_PARALLEL_N], uint64_t *digest[SHA512_PARALLEL_N]) {
     Sha512Context context[2];
-    context[0].h[0] = _mm_set1_epi64x(0x6A09E667F3BCC908);
-    context[0].h[1] = _mm_set1_epi64x(0xBB67AE8584CAA73B);
-    context[0].h[2] = _mm_set1_epi64x(0x3C6EF372FE94F82B);
-    context[0].h[3] = _mm_set1_epi64x(0xA54FF53A5F1D36F1);
-    context[0].h[4] = _mm_set1_epi64x(0x510E527FADE682D1);
-    context[0].h[5] = _mm_set1_epi64x(0x9B05688C2B3E6C1F);
-    context[0].h[6] = _mm_set1_epi64x(0x1F83D9ABFB41BD6B);
-    context[0].h[7] = _mm_set1_epi64x(0x5BE0CD19137E2179);
+    int i;
 
-    context[1].h[0] = _mm_set1_epi64x(0x6A09E667F3BCC908);
-    context[1].h[1] = _mm_set1_epi64x(0xBB67AE8584CAA73B);
-    context[1].h[2] = _mm_set1_epi64x(0x3C6EF372FE94F82B);
-    context[1].h[3] = _mm_set1_epi64x(0xA54FF53A5F1D36F1);
-    context[1].h[4] = _mm_set1_epi64x(0x510E527FADE682D1);
-    context[1].h[5] = _mm_set1_epi64x(0x9B05688C2B3E6C1F);
-    context[1].h[6] = _mm_set1_epi64x(0x1F83D9ABFB41BD6B);
-    context[1].h[7] = _mm_set1_epi64x(0x5BE0CD19137E2179);
-
-    for(int i=0; i<4; ++i) {
-        context[0].w[i] = _mm_set_epi64x ( data[1][i], data[0][i] );
-        context[1].w[i] = _mm_set_epi64x ( data[3][i], data[2][i] );
+    for (i=0 ; i<8; i++) {
+	context[0].h[i] = context[1].h[i] = _mm_set1_epi64x(init[i]);
     }
-    for(int i=0; i<10; ++i) {
-        context[0].w[i+4] = _mm_set1_epi64x( ((uint64_t*)padding)[i] );
-        context[1].w[i+4] = _mm_set1_epi64x( ((uint64_t*)padding)[i] );
+
+    for (i=0; i<4; ++i) {
+        context[0].w[i] = _mm_set_epi64x( data[1][i], data[0][i] );
+        context[1].w[i] = _mm_set_epi64x( data[3][i], data[2][i] );
+    }
+
+    for (i=0; i<10; ++i) {
+        context[0].w[i+4] = context[1].w[i+4] = _mm_set1_epi64x( padding[i] );
     }
 
     //Length of the original message (before padding)
     uint64_t totalSize = 32 * 8;
 
     //Append the length of the original message
-    context[0].w[14] = _mm_set1_epi64x(0);
-    context[0].w[15] = _mm_set1_epi64x(htobe64(totalSize));
-
-    context[1].w[14] = _mm_set1_epi64x(0);
-    context[1].w[15] = _mm_set1_epi64x(htobe64(totalSize));
+    context[0].w[14] = context[1].w[14] = _mm_set1_epi64x(0);
+    context[0].w[15] = context[1].w[15] = _mm_set1_epi64x(htobe64(totalSize));
 
     //Calculate the message digest
     sha512ProcessBlock(context);
 
     //Convert from host byte order to big-endian byte order
-    for (int i = 0; i < 8; i++) {
+    for (i = 0; i < 8; i++) {
         context[0].h[i] = mm_htobe_epi64(context[0].h[i]);
         context[1].h[i] = mm_htobe_epi64(context[1].h[i]);
     }
 
     //Copy the resulting digest
-    for(int i=0; i<8; ++i) {
+    for (i=0; i<8; ++i) {
         digest[0][i] = _mm_extract_epi64(context[0].h[i], 0);
         digest[1][i] = _mm_extract_epi64(context[0].h[i], 1);
         digest[2][i] = _mm_extract_epi64(context[1].h[i], 0);
@@ -133,8 +128,8 @@ void sha512Compute32b_parallel(uint64_t *data[SHA512_PARALLEL_N], uint64_t *dige
                             SIGMA4(block[n][i - 2]) + block[n][i - 7])
 
 #define ROUND512(a,b,c,d,e,f,g,h)   \
-    T0 += (h[0]) + SIGMA2(e[0]) + Ch((e[0]), (f[0]), (g[0])) + k[i]; \
-    T1 += (h[1]) + SIGMA2(e[1]) + Ch((e[1]), (f[1]), (g[1])) + k[i]; \
+    T0 += (h[0]) + SIGMA2(e[0]) + Ch((e[0]), (f[0]), (g[0])) + _mm_set1_epi64x(k[i]); \
+    T1 += (h[1]) + SIGMA2(e[1]) + Ch((e[1]), (f[1]), (g[1])) + _mm_set1_epi64x(k[i]); \
     (d[0]) += T0; \
     (d[1]) += T1; \
     (h[0]) = T0 + SIGMA1(a[0]) + Maj((a[0]), (b[0]), (c[0])); \


### PR DESCRIPTION
complied with clang:

```
Apple LLVM version 8.1.0 (clang-802.0.42)
Target: x86_64-apple-darwin16.7.0
Thread model: posix
```

compile parameters:
```
CFLAGS="-march=native -I/opt/local/include"
LDFLAGS="-L/opt/local/lib -Wl,-rpath,/opt/local/lib -lcurl"

```
Link info:

```
bash-3.2$ otool -L hodlminer 
hodlminer:
	/opt/local/lib/libcurl.4.dylib (compatibility version 10.0.0, current version 10.0.0)
	/opt/local/lib/libjansson.4.dylib (compatibility version 15.0.0, current version 15.0.0)
	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1238.60.2)
	/opt/local/lib/libssl.1.0.0.dylib (compatibility version 1.0.0, current version 1.0.0)
	/opt/local/lib/libcrypto.1.0.0.dylib (compatibility version 1.0.0, current version 1.0.0)
```
MacOS ports (https://www.macports.org/) installed in /opt/local (curl, openssl)

SSE2 and AVX2 both are supported, can be checked on PC with AVX2 using 

`CFLAGS="-march=native -mno-avx2"`

`CC=gcc` commented out to be able to change compiler executable.

Changes should be compatible with other platforms, tested on linux.