### PR TITLE
Show hashrate in LONGPOLL mining

### DIFF
--- a/hodl-miner.c
+++ b/hodl-miner.c
@@ -1466,9 +1466,19 @@ start:
 			goto out;
 		}
 		if (likely(val)) {
-			bool rc;
-			applog(LOG_INFO, "LONGPOLL pushed new work for block %d, target %04X",
-                                                    g_work.height, g_work.target[7]);
+
+                        bool rc;
+			char s[345];
+                        double hashrate = 0.;
+                        pthread_mutex_lock(&stats_lock);
+                        for (uint_fast16_t i = 0; i < opt_n_threads; i++)
+                            hashrate += thr_hashrates[i];
+                        pthread_mutex_unlock(&stats_lock);
+                        sprintf(s, hashrate >= 1e6 ? "%.0f" : "%.2f", hashrate);
+
+                        applog(LOG_INFO, "LONGPOLL pushed new work for block %d, target %04X, %s hash/s",
+                                    g_work.height, g_work.target[7], s);
+
 			res = json_object_get(val, "result");
 			soval = json_object_get(res, "submitold");
 			submit_old = soval ? json_is_true(soval) : false;


### PR DESCRIPTION
The output of LONGPOLL mining will be a little bit more informative:
```
[2018-01-15 15:32:44] LONGPOLL pushed new work for block 41234, target 02C8, 1708.34 hash/s
[2018-01-15 15:32:46] LONGPOLL pushed new work for block 41234, target 02C8, 1719.46 hash/s
[2018-01-15 15:33:42] LONGPOLL pushed new work for block 41235, target 02C8, 1717.64 hash/s
```
Otherwise it is possible to get hashrate only if block solved, and this may take some time.